### PR TITLE
Fix build error and remove client-side build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "jest",
-    "build": "cd client && npm install && npm run build"
+    "build": "echo 'No build step required for backend-only project'"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: llm-product-categorizer
     env: node
-    buildCommand: npm install && npm run build
+    buildCommand: npm install
     startCommand: node server.js
     envVars:
       - key: NODE_ENV
@@ -20,4 +20,3 @@ databases:
   - name: llm-product-categorizer-db
     databaseName: llm_product_categorizer
     user: llm_product_categorizer_user
-


### PR DESCRIPTION
## Summary of changes
This pull request addresses the build error occurring during deployment on Render and removes the unnecessary client-side build step, as our project is currently backend-only.

## Motivation/Context
The current build process was attempting to build a non-existent client directory, causing the deployment to fail. This change simplifies the build process and aligns it with our backend-only architecture.

## Implementation details
1. Modified `package.json`:
   - Removed the `build` script that was trying to access the `client` directory
   - Added a placeholder `build` script that echoes a message indicating no build step is required

2. Updated `render.yaml`:
   - Simplified the `buildCommand` to only run `npm install`
   - Removed references to the build step in the deployment process

## Potential impacts and considerations
- This change will allow successful deployment on Render
- Future frontend integration will require additional configuration changes
- Developers should be aware that there's no client-side build process at this time

Please review these changes and ensure they align with the project's current backend-focused state. Once approved, this should resolve the deployment issues on Render.